### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/scratch-gui/security/code-scanning/1](https://github.com/OmniBlocks/scratch-gui/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` key that restricts the GitHub Actions token to the minimum set of permissions required for the workflow to succeed. Since the workflow only checks out code and runs build/test commands locally (with no use of actions or scripts needing write access to contents, issues, or pull requests), the minimal required permission is `contents: read`. This can be defined at the workflow root (applies to all jobs), or within the `jobs.build` block. Root-level definition is recommended for maximum coverage.  
Change required: Insert the following block after the `name:` field and before `on:` in `.github/workflows/node.js.yml`:

```yaml
permissions:
  contents: read
```

No other functional or structural changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
