### PR TITLE
Potential fix for code scanning alert no. 5: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/lib/tw-username.js
+++ b/src/lib/tw-username.js
@@ -11,9 +11,14 @@ const generateRandomUsername = () => {
     } else if (typeof require === 'function') {
         // NodeJS fallback
         const crypto = require('crypto');
-        // Generate enough bytes for a secure random integer
-        // 4 bytes: up to 32 bits
-        randomNumber = crypto.randomBytes(4).readUInt32BE(0) % max;
+        // Use rejection sampling for unbiased random integer in [0, max)
+        const UINT32_MAX = 0xFFFFFFFF;
+        const limit = UINT32_MAX - (UINT32_MAX % max);
+        let rand;
+        do {
+            rand = crypto.randomBytes(4).readUInt32BE(0);
+        } while (rand >= limit);
+        randomNumber = rand % max;
     } else {
         // Fallback to Math.random (not secure - but not recommended)
         randomNumber = Math.floor(Math.random() * max);


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/scratch-gui/security/code-scanning/5](https://github.com/OmniBlocks/scratch-gui/security/code-scanning/5)

To fix this problem, we need to ensure that each value in the target range `[0, max)` is selected with equal probability. The standard approach is to perform "rejection sampling": repeatedly generate random numbers, and only accept those that fall in the largest subrange that fits within a multiple of `max`. In other words, we only use a random value if it's less than `floor((2^32) / max) * max`, and otherwise discard and retry. This guarantees a uniform, unbiased distribution. To implement this, in the Node.js (`require('crypto')`) branch, we:

- Calculate the maximum random value to accept (`limit`), so `(2^32 - (2^32 % max))`.
- Generate a random 32-bit integer, and if it's >= limit, re-draw.
- When an acceptable value is found, use `randomValue % max`.

This requires a loop (e.g., `do { ... } while (rand >= limit)`) in the Node.js branch on line 16.

No changes are needed outside the block involving random generation for Node. No new dependencies are required, as `crypto` suffices. Only the random value selection logic in the Node.js code path changes; variable and function names stay the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
