### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/src/addons/pull.js
+++ b/src/addons/pull.js
@@ -48,7 +48,13 @@ const clone = obj => JSON.parse(JSON.stringify(obj));
 const repoPath = pathUtil.resolve(__dirname, 'ScratchAddons');
 if (!process.argv.includes('-')) {
     rimraf.sync(repoPath);
-    childProcess.execSync(`git clone --depth=1 --branch=tw https://github.com/TurboWarp/addons ${repoPath}`);
+    childProcess.execFileSync("git", [
+        "clone",
+        "--depth=1",
+        "--branch=tw",
+        "https://github.com/TurboWarp/addons",
+        repoPath
+    ]);
 }
 
 for (const folder of ['addons', 'addons-l10n', 'addons-l10n-settings', 'libraries']) {


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/scratch-gui/security/code-scanning/2](https://github.com/OmniBlocks/scratch-gui/security/code-scanning/2)

To fix the problem, avoid constructing shell commands using unsafe string interpolation when including dynamic paths. Instead, use the child_process `execFileSync` method, which runs the command as an executable without invoking a shell, and accepts arguments as an array to safely pass dynamic values without shell interpretation.

Specifically, in `src/addons/pull.js`, replace the use of `childProcess.execSync` with string interpolation for the `git clone` command (line 51) with `childProcess.execFileSync`, passing `"git"` as the command and the remaining arguments—`clone`, `--depth=1`, `--branch=tw`, `https://github.com/TurboWarp/addons`, and the value of `repoPath`—as array elements. This fix ensures that the dynamic path is not interpreted by the shell and eliminates the injection risk.

You will need to ensure the correct usage of `execFileSync` (possibly including the encoding option if needed for output, but in this case, the command output is not used), but otherwise, no additional methods or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
