### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Build Monitor
+permissions:
+  contents: read
+  issues: write
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/scratch-gui/security/code-scanning/10](https://github.com/OmniBlocks/scratch-gui/security/code-scanning/10)

The best way to address this issue is by explicitly specifying the permissions required by the workflow, limiting the GITHUB_TOKEN permissions to the minimum set necessary. In this case, the workflow creates and comments on issues using the GitHub API, so it needs `contents: read` (for checkout, etc.) and `issues: write` (for issue creation/commenting). This should be set at the workflow level (above `jobs:`), so it covers all jobs, unless further granularity is required in future. The change involves adding the following block near the top of `.github/workflows/test.yml`, right after the workflow's name and before the `on:` or `jobs:` blocks:

```yaml
permissions:
  contents: read
  issues: write
```

No imports or extra definitions are needed—this is purely a configuration change in the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
