### PR TITLE
Fix Lack of Audio in media recorder addon, fixes another stuiid bug oversight

### DIFF
--- a/src/addons/addons/mediarecorder/userscript.js
+++ b/src/addons/addons/mediarecorder/userscript.js
@@ -409,7 +409,7 @@ if (selectedFormat === "mp4") {
   const mp4WithCodecs = "video/mp4; codecs=avc1,mp4a.40.2";
   if (MediaRecorder.isTypeSupported(mp4WithCodecs)) {
     recordMimeType = mp4WithCodecs;
-  } else if (supportedMimeTypes.includes("video/mp4")) {
+  } else if (MediaRecorder.isTypeSupported("video/mp4")) {
     recordMimeType = "video/mp4";
   } else {
     // Fall back to WebM if MP4 not supported

--- a/src/addons/addons/mediarecorder/userscript.js
+++ b/src/addons/addons/mediarecorder/userscript.js
@@ -400,15 +400,24 @@ export default async ({ addon, console, msg }) => {
         stream.addTrack(dest.stream.getAudioTracks()[0]);
       }
       
-      // Determine recording format
-      const selectedFormat = opts.format || defaultFileExtension;
-      let recordMimeType;
-      
-      if (selectedFormat === "mp4" && supportedMimeTypes.includes("video/mp4")) {
-        recordMimeType = "video/mp4";
-      } else {
-        recordMimeType = supportedMimeTypes.find(m => m.startsWith("video/webm")) || defaultMimeType;
-      }
+// Determine recording format
+const selectedFormat = opts.format || defaultFileExtension;
+let recordMimeType;
+
+if (selectedFormat === "mp4") {
+  // Try MP4 with specific codec support for audio
+  const mp4WithCodecs = "video/mp4; codecs=avc1,mp4a.40.2";
+  if (MediaRecorder.isTypeSupported(mp4WithCodecs)) {
+    recordMimeType = mp4WithCodecs;
+  } else if (supportedMimeTypes.includes("video/mp4")) {
+    recordMimeType = "video/mp4";
+  } else {
+    // Fall back to WebM if MP4 not supported
+    recordMimeType = supportedMimeTypes.find(m => m.startsWith("video/webm")) || defaultMimeType;
+  }
+} else {
+  recordMimeType = supportedMimeTypes.find(m => m.startsWith("video/webm")) || defaultMimeType;
+}
       
       recorder = new MediaRecorder(stream, { mimeType: recordMimeType });
       recorder.ondataavailable = (e) => {


### PR DESCRIPTION
Fixes #94

### Resolves

_What Github issue does this resolve (please include link)?_

- Resolves #94
https://github.com/OmniBlocks/scratch-gui/issues/94

### Proposed Changes

_Describe what this Pull Request does_
fixes lack of audio when recording mp4

### Reason for Changes

_Explain why these changes should be made_
you really want to download an mp4 with no soudn

### Test Coverage

_Please show how you have added tests to cover your changes_
uhh... test... whats a test XD

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved recording format detection to prefer MP4 when fully supported, with codec-aware checks, and fall back to WebM as needed.
  - Reduces failed recordings and playback issues, enhancing compatibility across browsers and media players.
  - More reliable defaults when no suitable format is available, minimizing errors during recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->