### PR TITLE
fix mp4 timestamps Media Recorder Addon Broken timestamp

### DIFF
--- a/src/addons/addons/mediarecorder/userscript.js
+++ b/src/addons/addons/mediarecorder/userscript.js
@@ -287,7 +287,23 @@ export default async ({ addon, console, msg }) => {
         ffmpeg.FS('writeFile', inputName, new Uint8Array(arrayBuffer));
         
         // Convert to MP4
-        await ffmpeg.run('-i', inputName, '-c', 'copy', outputName);
+        // Convert to MP4 with proper timestamp normalization
+        // -fflags +genpts: generate missing PTS timestamps
+        // -reset_timestamps 1: start streams at timestamp 0
+        // -movflags +faststart: move moov atom to beginning for seeking
+        // -avoid_negative_ts make_zero: clamp negative timestamps to 0
+        // -c:v copy: copy video stream without re-encoding
+        // -c:a aac: encode audio to AAC for MP4 compatibility
+        await ffmpeg.run(
+        '-i', inputName,
+        '-fflags', '+genpts',
+        '-reset_timestamps', '1',
+        '-movflags', '+faststart',
+        '-avoid_negative_ts', 'make_zero',
+        '-c:v', 'copy',
+        '-c:a', 'aac', '-b:a', '192k',
+        outputName
+        );
         
         // Read converted file
         const data = ffmpeg.FS('readFile', outputName);


### PR DESCRIPTION
Fixes #131

### Resolves

_What Github issue does this resolve (if any, if not then please include link)?_
#131

- Resolves #

### Proposed Changes

_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made. Why is this helpful or necessary? Why should this be added?_

### Test Coverage

_Please show how you have added tests to cover your changes_

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MP4 export/playback reliability by normalizing timestamps and enhancing cross-player/browser compatibility.
  * Faster video start and seeking through optimized container settings.
  * Reduced occurrences of negative/invalid timestamps and audio/video desync.
  * Increased audio compatibility by encoding to AAC at 192 kbps.
  * Fewer conversion failures and more consistent output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->