### PR TITLE
uses correct app version not hard coded #152

### DIFF
--- a/src/lib/brand.js
+++ b/src/lib/brand.js
@@ -2,5 +2,5 @@
 // eslint-disable-next-line import/no-commonjs
 module.exports = {
     APP_NAME: 'OmniBlocks', // the name of the mod
-    APP_VERSION: 'v0.5.7-alpha' // Used to define what version the mod is
+    APP_VERSION: process.env.APP_VERSION || 'v0.5.8-alpha' // Dynamically injected at build time from git tags
 };


### PR DESCRIPTION
### Resolves

_What Github issue does this resolve (if any, if not then please include link)?_

- Resolves #152

### Proposed Changes
i need a way for the app version to not be hardcoded
currently in brand js
it's just this
// Legacy export format because this is used by some build-time scripts stuck in the past.
// eslint-disable-next-line import/no-commonjs
module.exports = {
APP_NAME: 'OmniBlocks', // the name of the mod
APP_VERSION: 'v0.5.7-alpha' // Used to define what version the mod is
};

whiich means the app version is hardcoded and not very convenient for obvious reasons. it's supposed to match the latest github release.
_Describe what this Pull Request does_

### Reason for Changes

_Explain why these changes should be made. Why is this helpful or necessary? Why should this be added?_

### Test Coverage

_Please show how you have added tests to cover your changes_
no tests but i think it works :)
### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version handling so the app’s displayed version updates automatically based on the build, ensuring accurate version information across environments.
  * Updated the default app version to v0.5.8-alpha.
  * Enhances consistency for users seeing the correct version in the UI without requiring manual updates or user action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->