### PR TITLE
Potential fix for code scanning alert no. 50: Code injection

### DIFF
--- a/.github/workflows/prtest.yml
+++ b/.github/workflows/prtest.yml
@@ -883,11 +883,6 @@ jobs:
 
       - name: Update comment - Accessibility Testing
         uses: actions/github-script@v7
-        env:
-          A11Y_SUCCESS: ${{ steps.a11y_test.outputs.a11y_success }}
-          A11Y_PARSED: ${{ steps.a11y_parse.outputs.a11y_parsed }}
-          A11Y_VIOLATIONS: ${{ steps.a11y_test.outputs.violations }}
-          A11Y_PASSES: ${{ steps.a11y_test.outputs.passes }}
         with:
           script: |
             const initial_spinner = '<img src="https://lh5.googleusercontent.com/proxy/OUqG0HgVNVMNorlPCmI4VgJa-3h7uHLkkMy9vdJ0eRsQlvJBytFUS-HvuW-O9EJd-c9xB7KAqlwby4Fzp59g1705FzBuP-F8dC1ZaBQtmLeCu5i6FfSd6Mmzh8mjOwgrEYZwy5UStg" width="20" height="20">';
@@ -1028,6 +1023,11 @@ jobs:
       - name: Update comment with full results
         if: success()
         uses: actions/github-script@v7
+        env:
+          A11Y_TEST_SUCCESS: ${{ steps.a11y_test.outputs.a11y_success }}
+          A11Y_PARSE_SUCCESS: ${{ steps.a11y_parse.outputs.a11y_parsed }}
+          A11Y_VIOLATION_COUNT: ${{ steps.a11y_test.outputs.violations }}
+          A11Y_PASS_COUNT: ${{ steps.a11y_test.outputs.passes }}
         with:
           script: |
             const fs = require('fs');
@@ -1143,10 +1143,10 @@ jobs:
             }
             
             // Accessibility results WITH DETAILED VIOLATIONS
-            const a11ySuccess = process.env.A11Y_SUCCESS === 'true';
-            const a11yParsed = process.env.A11Y_PARSED === 'true';
-            const a11yViolations = process.env.A11Y_VIOLATIONS;
-            const a11yPasses = process.env.A11Y_PASSES;
+            const a11ySuccess = process.env.A11Y_TEST_SUCCESS === 'true';
+            const a11yParsed = process.env.A11Y_PARSE_SUCCESS === 'true';
+            const a11yViolations = process.env.A11Y_VIOLATION_COUNT;
+            const a11yPasses = process.env.A11Y_PASS_COUNT;
             let a11ySection = '';
             
             if (a11ySuccess && a11yViolations !== 'error') {


### PR DESCRIPTION
Potential fix for [https://github.com/OmniBlocks/scratch-gui/security/code-scanning/50](https://github.com/OmniBlocks/scratch-gui/security/code-scanning/50)

The correct fix is to avoid direct interpolation of untrusted inputs using `${{ ... }}` inside string templates for github-script steps. Instead, pass such outputs as environment variables using `env:` and then access them with `process.env` inside the JavaScript code. For this error, do the following in the affected github-script step:

- In the relevant github-script "with:" block, add an `env:` section that maps environment variable names to the workflow output expressions (e.g. `A11Y_VIOLATIONS: ${{ steps.a11y_test.outputs.violations }}`).
- In the script, replace any use of the direct `${{ steps.a11y_test.outputs.violations }}` with `process.env.A11Y_VIOLATIONS`.
- Repeat this pattern for any other related outputs that may be interpolated (e.g. `passes`).

Apply this fix only to the lines shown in the post-processing block where the interpolation occurs (lines 1141–1144).  
No new dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
