### PR TITLE
Change order of file menu to be more familiar and consistent

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -634,22 +634,7 @@ class MenuBar extends React.Component {
                                         >
                                             {this.props.intl.formatMessage(sharedMessages.loadFromComputerTitle)}
                                         </MenuItem>
-                                        <SB3FolderImporter>
-                                            {importProjectFromFolder => (
-                                                importProjectFromFolder ? (
-                                                    <MenuItem
-                                                        onClick={importProjectFromFolder}
-                                                    >
-                                                        <FormattedMessage
-                                                            defaultMessage="Import from folder"
-                                                            // eslint-disable-next-line max-len
-                                                            description="Menu bar item to import project files from a folder"
-                                                            id="tw.importProjectFromFolder"
-                                                        />
-                                                    </MenuItem>
-                                                ) : null
-                                            )}
-                                        </SB3FolderImporter>
+                                        
                                         <SB3Downloader
                                             showSaveFilePicker={this.props.showSaveFilePicker}
                                         >
@@ -705,6 +690,22 @@ class MenuBar extends React.Component {
                                                 </React.Fragment>
                                             )}
                                         </SB3Downloader>
+                                        <SB3FolderImporter>
+                                            {importProjectFromFolder => (
+                                                importProjectFromFolder ? (
+                                                    <MenuItem
+                                                        onClick={importProjectFromFolder}
+                                                    >
+                                                        <FormattedMessage
+                                                            defaultMessage="Import from folder"
+                                                            // eslint-disable-next-line max-len
+                                                            description="Menu bar item to import project files from a folder"
+                                                            id="tw.importProjectFromFolder"
+                                                        />
+                                                    </MenuItem>
+                                                ) : null
+                                            )}
+                                        </SB3FolderImporter>
                                         <SB3FolderExporter>
                                             {exportProjectToFolder => (
                                                 exportProjectToFolder ? (


### PR DESCRIPTION
A new feature was added called "Import from folder". 
It was added to the top of the file menu. This is bad for two reasons:
- it breaks muscle memory for the option "Load from your computer" which is the top option in both TurboWarp and Scratch.
- it is inconsistent since you would expect the import option to be next to the export, and they are not

tested:

- [X] Chrome on Windows
